### PR TITLE
feat: :sparkles: subject is required && add subjectMinLength

### DIFF
--- a/src/lib/commitlint.ts
+++ b/src/lib/commitlint.ts
@@ -19,6 +19,7 @@ export type CommitlintRules = {
   typeEnum: string[];
   scopeEnum: string[];
   subjectMaxLength: number;
+  subjectMinLength: number;
   bodyMaxLength: number;
   footerMaxLength: number;
 };
@@ -43,6 +44,7 @@ export async function getRules({
     typeEnum: getRuleValue<string[]>('type-enum', []), // [] means use the default types
     scopeEnum: getRuleValue<string[]>('scope-enum', []), // [] means everything is ok
     subjectMaxLength: getRuleValue<number>('subject-max-length', Infinity),
+    subjectMinLength: getRuleValue<number>('subject-min-length', 0),
     bodyMaxLength: getRuleValue<number>('body-max-length', Infinity),
     footerMaxLength: getRuleValue<number>('footer-max-length', Infinity),
   };

--- a/src/lib/commitlint.ts
+++ b/src/lib/commitlint.ts
@@ -18,6 +18,7 @@ async function loadRules(cwd: string) {
 export type CommitlintRules = {
   typeEnum: string[];
   scopeEnum: string[];
+  subjectEmpty: string;
   subjectMaxLength: number;
   subjectMinLength: number;
   bodyMaxLength: number;
@@ -43,6 +44,7 @@ export async function getRules({
   return {
     typeEnum: getRuleValue<string[]>('type-enum', []), // [] means use the default types
     scopeEnum: getRuleValue<string[]>('scope-enum', []), // [] means everything is ok
+    subjectEmpty: getRuleValue<string>('subject-empty', 'never'),
     subjectMaxLength: getRuleValue<number>('subject-max-length', Infinity),
     subjectMinLength: getRuleValue<number>('subject-min-length', 0),
     bodyMaxLength: getRuleValue<number>('body-max-length', Infinity),

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -145,7 +145,11 @@ export default async function prompts({
       name: 'subject',
       placeholder: 'Write a short, imperative tense description of the change.',
       validate(input: string) {
-        if (input.length > commlintRules.subjectMaxLength) {
+        if (input.length === 0) {
+          return `Subject is required.`;
+        } else if (input.length < commlintRules.subjectMinLength) {
+          return `Subject has less than ${commlintRules.subjectMinLength} characters.`;
+        } else if (input.length > commlintRules.subjectMaxLength) {
           return `Subject has more than ${commlintRules.subjectMaxLength} characters.`;
         }
       },

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -145,10 +145,10 @@ export default async function prompts({
       name: 'subject',
       placeholder: 'Write a short, imperative tense description of the change.',
       validate(input: string) {
-        if (input.length === 0) {
-          return `Subject is required.`;
+        if (commlintRules.subjectEmpty === 'never' && input.length === 0) {
+          return 'Subject may not be empty.';
         } else if (input.length < commlintRules.subjectMinLength) {
-          return `Subject has less than ${commlintRules.subjectMinLength} characters.`;
+          return `Subject must not be shorter than ${commlintRules.subjectMinLength} characters.`;
         } else if (input.length > commlintRules.subjectMaxLength) {
           return `Subject has more than ${commlintRules.subjectMaxLength} characters.`;
         }


### PR DESCRIPTION
新增了subject的非空判断，同时并新增了读取本地commitlint中rules的subject-min-length属性。