### PR TITLE
fix(typo): workspacceFolders -> workspaceFolders

### DIFF
--- a/src/lib/conventional-commits.ts
+++ b/src/lib/conventional-commits.ts
@@ -68,7 +68,7 @@ async function getRepository({
       .join(', ')}`,
   );
   output.appendLine(
-    `workspacceFolders: ${workspaceFolders
+    `workspaceFolders: ${workspaceFolders
       ?.map(function (folder) {
         return folder.uri.fsPath;
       })


### PR DESCRIPTION
I ran into this typo while working on a custom feature for this extension, figured you might appreciate a PR.