### PR TITLE
feat: add option to open the full commit message in a separate tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
           "type": "string",
           "default": "",
           "markdownDescription": "%extension.configuration.properties.conventionalCommits.lineBreak.markdownDescription%"
+        },
+        "conventionalCommits.showEditor": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "%extension.configuration.properties.conventionalCommits.showEditor.markdownDescription%"
         }
       }
     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,6 +6,7 @@
   "extension.configuration.properties.conventionalCommits.emojiFormat.markdownEnumDescriptions.emoji": "Display as `🐛`",
   "extension.configuration.properties.conventionalCommits.scopes.markdownDescription": "Available scopes.",
   "extension.configuration.properties.conventionalCommits.lineBreak.markdownDescription": "Treat words as line breaks.\n\nBlank means no line breaks.",
+  "extension.configuration.properties.conventionalCommits.showEditor.markdownDescription": "Show the commit message as a text document in a separate tab.",
   "extension.sources.repositoryNotFoundInPath": "Repository not found in path: ",
   "extension.sources.repositoriesEmpty": "Please open a repository.",
   "extension.sources.promptRepositoryPlaceholder": "Choose a repository",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -6,6 +6,7 @@
   "extension.configuration.properties.conventionalCommits.emojiFormat.markdownEnumDescriptions.emoji": "显示为 `🐛`",
   "extension.configuration.properties.conventionalCommits.scopes.markdownDescription": "可选作用域。",
   "extension.configuration.properties.conventionalCommits.lineBreak.markdownDescription": "换行标识符。\n\n留空表示不换行。",
+  "extension.configuration.properties.conventionalCommits.showEditor.markdownDescription": "在新标签页用文本编辑器展示提交信息",
   "extension.sources.repositoryNotFoundInPath": "以下路径中未找到仓库：",
   "extension.sources.repositoriesEmpty": "请打开一个仓库",
   "extension.sources.promptRepositoryPlaceholder": "请选择一个仓库",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import createConventionalCommits from './lib/conventional-commits';
 import * as output from './lib/output';
 import * as localize from './lib/localize';
+import CommitProvider from './lib/editor/provider';
 
 export function activate(context: vscode.ExtensionContext) {
   output.initialize();
@@ -20,6 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(disposable);
+  vscode.workspace.registerFileSystemProvider('commit-message', CommitProvider);
 }
 
 export function deactivate() {}

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -14,6 +14,7 @@ export type Configuration = {
   autoCommit: boolean;
   gitmoji: boolean;
   emojiFormat: EMOJI_FORMAT;
+  showEditor: boolean;
   scopes: string[];
   lineBreak: string;
 };

--- a/src/lib/editor/index.ts
+++ b/src/lib/editor/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @since 2021-01-29 11:09
+ * @author sbacic
+ */
+
+import * as vscode from 'vscode';
+import * as VSCodeGit from '../../vendors/git';
+import { state } from './provider';
+
+/**
+ * Opens a new empty file and adds the commit message. The language mode is set to "Git Commit Message" and
+ * the FileSystemProvider is set to CommitProvider.
+ * @param repository The project repository.
+ */
+export default async function openMessageInTab(
+  repository: VSCodeGit.Repository,
+) {
+  state.repository = repository;
+  const uri = vscode.Uri.file('COMMIT_EDITMSG').with({
+    scheme: 'commit-message',
+  });
+  await vscode.commands.executeCommand('vscode.open', uri);
+}

--- a/src/lib/editor/provider.ts
+++ b/src/lib/editor/provider.ts
@@ -1,0 +1,85 @@
+import * as vscode from 'vscode';
+import { TextDecoder, TextEncoder } from 'util';
+import localize from '../localize';
+import { Repository } from '../../vendors/git';
+import * as configuration from '../configuration';
+import * as output from '../output';
+
+interface State {
+  repository?: Repository;
+}
+
+export const state: State = {
+  repository: undefined,
+};
+
+/**
+ * Simplified provider for handling Git commit messages.
+ * On save, the contents are instead autocommited or used to update repository object (depending on settings).
+ */
+const CommitProvider = new (class implements vscode.FileSystemProvider {
+  private _emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+  readonly onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]> = this
+    ._emitter.event;
+
+  watch(_resource: vscode.Uri): vscode.Disposable {
+    return new vscode.Disposable(() => {});
+  }
+
+  stat(): vscode.FileStat {
+    return {
+      type: vscode.FileType.File,
+      ctime: Date.now(),
+      mtime: Date.now(),
+      size: 0,
+    };
+  }
+
+  readDirectory() {
+    return [];
+  }
+
+  readFile(_uri: vscode.Uri): Uint8Array {
+    const enc = new TextEncoder();
+    return enc.encode(state.repository?.inputBox.value);
+  }
+
+  createDirectory(): void {}
+  writeFile(_uri: vscode.Uri, content: Uint8Array): Thenable<void> {
+    return new Promise(async (resolve) => {
+      try {
+        const value = new TextDecoder().decode(content);
+
+        if (state.repository) {
+          const autoCommit = configuration.get<boolean>('autoCommit');
+          state.repository.inputBox.value = value;
+          vscode.commands.executeCommand(
+            'workbench.action.revertAndCloseActiveEditor',
+          );
+
+          if (autoCommit) {
+            await vscode.commands.executeCommand(
+              'git.commit',
+              state.repository,
+            );
+            resolve();
+          } else {
+            await vscode.commands.executeCommand('workbench.view.scm');
+            resolve();
+          }
+
+          output.appendLine('Finished successfully.');
+        }
+      } catch (e) {
+        output.appendLine(`Finished with an error: ${e.stack}`);
+        vscode.window.showErrorMessage(
+          `${localize('extension.name')}: ${e.message}`,
+        );
+      }
+    });
+  }
+  rename(): void {}
+  delete(): void {}
+})();
+
+export default CommitProvider;

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -26,10 +26,12 @@ import localize from './localize';
 
 export default async function prompts({
   gitmoji,
+  showEditor,
   emojiFormat,
   lineBreak,
 }: {
   gitmoji: boolean;
+  showEditor: boolean;
   emojiFormat: configuration.EMOJI_FORMAT;
   lineBreak: string;
 }): Promise<CommitMessage> {
@@ -235,10 +237,16 @@ export default async function prompts({
     },
   ]
     .filter(function (question) {
-      if (gitmoji) {
+      if (!gitmoji && question.name === 'gitmoji') {
+        return false;
+      } else if (
+        showEditor &&
+        (question.name === 'body' || question.name === 'footer')
+      ) {
+        return false;
+      } else {
         return true;
       }
-      return question.name !== 'gitmoji';
     })
     .map(function (question, index, array) {
       return {


### PR DESCRIPTION
Add a new configuration option: "showEditor" that displays
the commit message in a separate tab as a text document the user can edit.
If autoCommit is set to true, saving the file will automatically commit the
message. If autoCommit is set to false, it will paste the contents
into the scm as usual and close the tab.

Note: I wrote this because I noticed I was either omitting the commit body or `amending` it from the command line afterwards. For whatever reason, the small input box in the scm just never sat well with me. This feature also opens the possibility of adding support for commit templates and programmatic language features.