### PR TITLE
ci(build): use the more limited token for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - "package*"
       - "**/build.yml"
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [labeled]
 
 jobs:


### PR DESCRIPTION
The build system can run under the token, which has the single
permission of `read`.

1. the token for `pull request` is more limited than `pull_request_target`.
See warning in [docs#pull_request_target].

2. If the PR is labeled as `wait-to-build`, it can make a package.

3. fix the `pull_request_target` pull the `master` branch issue,
and the `pull request` will run well, because it pulls the head branch
of the labeled PR.
See in [docs#pull_request].

[docs#pull_request_target]:
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target

[docs#pull_request]:
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request