### PR TITLE
feat(scope): :sparkles: add option to disable scope prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can access VSCode Conventional Commits in two ways:
    and press `Enter`.
 2. Click the icon on the Source Control menu. See the image below.
 
-<img src="./assets/docs/icon-on-the-source-control-menu.png" alt="Icon on the Source Control menu" width="300">
+![Icon on the Source Control menu](./assets/docs/icon-on-the-source-control-menu.png)
 
 ## Commit Workflow
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "💬Conventional Commits for VSCode.",
   "icon": "assets/icon.png",
   "publisher": "vivaxy",
-  "version": "1.17.0",
+  "version": "1.17.1-1",
   "engines": {
     "vscode": "^1.14.0"
   },
@@ -94,6 +94,11 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "%extension.configuration.properties.conventionalCommits.showEditor.markdownDescription%"
+        },
+        "conventionalCommits.promptScopes": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "%extension.configuration.properties.conventionalCommits.promptScopes.markdownDescription%"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "💬Conventional Commits for VSCode.",
   "icon": "assets/icon.png",
   "publisher": "vivaxy",
-  "version": "1.17.1-1",
+  "version": "1.17.0",
   "engines": {
     "vscode": "^1.14.0"
   },

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,10 +1,11 @@
 {
   "extension.name": "Conventional Commits",
   "extension.configuration.properties.conventionalCommits.autoCommit.markdownDescription": "Controls whether the extension should automatically commit files.\n\n*Enable `Settings > git.enableSmartCommit` and set `Settings > git.smartCommitChanges` to `all` to commit all changes when there are no staged changes.*\n\n*Set `Settings > git.postCommitCommand` to `sync` to run `git.sync` after commit.*",
-  "extension.configuration.properties.conventionalCommits.gitmoji.markdownDescription": "Controls whether the extension should prompt for an gitmoji.",
+  "extension.configuration.properties.conventionalCommits.gitmoji.markdownDescription": "Controls whether the extension should prompt for a gitmoji.",
   "extension.configuration.properties.conventionalCommits.emojiFormat.markdownEnumDescriptions.code": "Display as `:bug:`",
   "extension.configuration.properties.conventionalCommits.emojiFormat.markdownEnumDescriptions.emoji": "Display as `🐛`",
   "extension.configuration.properties.conventionalCommits.scopes.markdownDescription": "Available scopes.",
+  "extension.configuration.properties.conventionalCommits.promptScopes.markdownDescription": "Controls whether the extension should prompt for a scope.",
   "extension.configuration.properties.conventionalCommits.lineBreak.markdownDescription": "Treat words as line breaks.\n\nBlank means no line breaks.",
   "extension.configuration.properties.conventionalCommits.showEditor.markdownDescription": "Show the commit message as a text document in a separate tab.",
   "extension.sources.repositoryNotFoundInPath": "Repository not found in path: ",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,10 +1,11 @@
 {
   "extension.name": "约定式提交",
   "extension.configuration.properties.conventionalCommits.autoCommit.markdownDescription": "是否自动提交改动。\n\n*打开 `Settings > git.enableSmartCommit` 并设置 `Settings > git.smartCommitChanges` 为 `all` 可以在无暂存内容时，自动将所有改动提交。*\n\n*设置 `Settings > git.postCommitCommand` 为 `sync` 可以在提交后自动执行 `git.sync`。*",
-  "extension.configuration.properties.conventionalCommits.gitmoji.markdownDescription": "是否需要填写 gitmoji。",
+  "extension.configuration.properties.conventionalCommits.gitmoji.markdownDescription": "是否需要填写 `gitmoji`。",
   "extension.configuration.properties.conventionalCommits.emojiFormat.markdownEnumDescriptions.code": "显示为 `:bug:`",
   "extension.configuration.properties.conventionalCommits.emojiFormat.markdownEnumDescriptions.emoji": "显示为 `🐛`",
   "extension.configuration.properties.conventionalCommits.scopes.markdownDescription": "可选作用域。",
+  "extension.configuration.properties.conventionalCommits.promptScopes.markdownDescription": "是否需要填写作用域。",
   "extension.configuration.properties.conventionalCommits.lineBreak.markdownDescription": "换行标识符。\n\n留空表示不换行。",
   "extension.configuration.properties.conventionalCommits.showEditor.markdownDescription": "在新标签页用文本编辑器展示提交信息",
   "extension.sources.repositoryNotFoundInPath": "以下路径中未找到仓库：",

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -17,6 +17,7 @@ export type Configuration = {
   showEditor: boolean;
   scopes: string[];
   lineBreak: string;
+  promptScopes: boolean;
 };
 
 export function getConfiguration() {

--- a/src/lib/conventional-commits.ts
+++ b/src/lib/conventional-commits.ts
@@ -138,6 +138,7 @@ export default function createConventionalCommits() {
       outputConfiguration('emojiFormat');
       outputConfiguration('scopes');
       outputConfiguration('lineBreak');
+      outputConfiguration('promptScopes');
 
       outputRelatedExtensionConfigutation('git.enableSmartCommit');
       outputRelatedExtensionConfigutation('git.smartCommitChanges');
@@ -176,6 +177,7 @@ export default function createConventionalCommits() {
           'emojiFormat',
         ),
         lineBreak: configuration.get<string>('lineBreak'),
+        promptScopes: configuration.get<boolean>('promptScopes'),
       });
       output.appendLine(
         `commitMessage: ${JSON.stringify(commitMessage, null, 2)}`,

--- a/src/lib/conventional-commits.ts
+++ b/src/lib/conventional-commits.ts
@@ -35,7 +35,7 @@ function outputConfiguration(key: keyof configuration.Configuration) {
   output.appendLine(`${key}: ${configuration.get(key)}`);
 }
 
-function outputRelatedExtensionConfigutation(key: string) {
+function outputRelatedExtensionConfiguration(key: string) {
   output.appendLine(`${key}: ${configuration.getConfiguration().get(key)}`);
 }
 
@@ -140,9 +140,9 @@ export default function createConventionalCommits() {
       outputConfiguration('lineBreak');
       outputConfiguration('promptScopes');
 
-      outputRelatedExtensionConfigutation('git.enableSmartCommit');
-      outputRelatedExtensionConfigutation('git.smartCommitChanges');
-      outputRelatedExtensionConfigutation('git.postCommitCommand');
+      outputRelatedExtensionConfiguration('git.enableSmartCommit');
+      outputRelatedExtensionConfiguration('git.smartCommitChanges');
+      outputRelatedExtensionConfiguration('git.postCommitCommand');
 
       // 2. check git
       const git = getGitAPI();

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -29,11 +29,13 @@ export default async function prompts({
   showEditor,
   emojiFormat,
   lineBreak,
+  promptScopes,
 }: {
   gitmoji: boolean;
   showEditor: boolean;
   emojiFormat: configuration.EMOJI_FORMAT;
   lineBreak: string;
+  promptScopes: boolean;
 }): Promise<CommitMessage> {
   const conventionalCommitsTypes = getConventionalCommitsTypesByLocale(locale);
 
@@ -252,7 +254,9 @@ export default async function prompts({
     },
   ]
     .filter(function (question) {
-      if (!gitmoji && question.name === 'gitmoji') {
+      if (!promptScopes && question.name === 'scope') {
+        return false;
+      } else if (!gitmoji && question.name === 'gitmoji') {
         return false;
       } else if (
         showEditor &&

--- a/src/lib/prompts/prompt-types.ts
+++ b/src/lib/prompts/prompt-types.ts
@@ -129,8 +129,8 @@ async function createConfigurableQuickPick({
   newItemWithoutSetting,
   validate = () => undefined,
 }: ConfigurableQuickPickOptions): Promise<string> {
-  const currentValus: string[] = configuration.get<string[]>(configurationKey);
-  const items: Item[] = currentValus.map(function (value) {
+  const currentValues: string[] = configuration.get<string[]>(configurationKey);
+  const items: Item[] = currentValues.map(function (value) {
     return {
       label: value,
       description: '',
@@ -154,7 +154,7 @@ async function createConfigurableQuickPick({
       validate,
     });
     if (selectedValue) {
-      configuration.update(configurationKey, [...currentValus, selectedValue]);
+      configuration.update(configurationKey, [...currentValues, selectedValue]);
     }
   }
   if (selectedValue === newItemWithoutSetting.label) {


### PR DESCRIPTION
Add `conventionalCommits.promptScopes` option to disable scope prompt.

Close #43