### PR TITLE
feat: :sparkles: add back button

### DIFF
--- a/src/lib/prompts/quick-pick.ts
+++ b/src/lib/prompts/quick-pick.ts
@@ -7,29 +7,38 @@ import * as vscode from 'vscode';
 export default function createQuickPick<T extends vscode.QuickPickItem>({
   placeholder,
   items = [],
+  value = '',
   format = (i) => i,
   step,
   totalSteps,
+  buttons = [],
 }: Partial<
   vscode.QuickPick<T> & {
     format(i: T[]): T[];
   }
 >): Promise<T[]> {
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve, reject) {
     const picker = vscode.window.createQuickPick();
     picker.placeholder = placeholder;
     picker.matchOnDescription = true;
     picker.matchOnDetail = true;
     picker.ignoreFocusOut = true;
     picker.items = items;
+    picker.value = value;
     picker.step = step;
     picker.totalSteps = totalSteps;
+    picker.buttons = buttons;
     picker.show();
     picker.onDidAccept(function () {
       if (picker.selectedItems.length) {
         const result = format(picker.selectedItems as T[]);
         picker.dispose();
         resolve(result);
+      }
+    });
+    picker.onDidTriggerButton(function (e) {
+      if (e === vscode.QuickInputButtons.Back) {
+        reject({ button: e, value: picker.value });
       }
     });
   });


### PR DESCRIPTION
Thanks for developing this great extension.
I implemented a back button because I sometimes wanted to change the previous input value while answering a question.
Retain previous questions and values in middle of inputs, as shown in the gif below.

![conventional-commits](https://user-images.githubusercontent.com/74579078/130114392-80f58409-efc3-451c-8c0b-abb65f69e47e.gif)

In the case of `QuickPick`, it is possible that `selectedItems` would be preferred over `value` as a default when we are back, but I haven't done so because it would require major code changes to do so.