### PR TITLE
fix: patch import.meta.url in @commitlint v20 ESM bundle (#383)

### DIFF
--- a/e2e-test/suite/bundle-check.test.ts
+++ b/e2e-test/suite/bundle-check.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test for issue #383: Windows activation crash caused by bare
+ * `import.meta.url` references surviving into `dist/extension.js` after the
+ * @commitlint/load v20 ESM migration.
+ *
+ * The `yarn test:e2e` script runs `yarn webpack` before launching the VS Code
+ * host, so `dist/extension.js` is already built when this test executes.
+ * We simply read the bundle and assert that no `import.meta.url` occurrences
+ * remain — any surviving occurrence would crash the extension on Windows where
+ * CommonJS bundles do not support `import.meta`.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// `__dirname` resolves to the compiled `e2e-test/out/suite/` directory.
+// Three levels up (suite → out → e2e-test → repo root) lands at the repo root;
+// `dist/extension.js` is a direct child of that root.
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const bundlePath = path.join(repoRoot, 'dist', 'extension.js');
+
+suite('bundle sanity checks', () => {
+  test('dist/extension.js contains no import.meta.url (issue #383 regression)', () => {
+    const source = fs.readFileSync(bundlePath, 'utf8');
+    const matches = source.match(/import\.meta\.url/g);
+    assert.strictEqual(
+      matches === null ? 0 : matches.length,
+      0,
+      `dist/extension.js must not contain any 'import.meta.url' occurrences ` +
+        `(issue #383 — Windows activation crash). ` +
+        `Found ${matches ? matches.length : 0} occurrence(s). ` +
+        `Check that all string-replace-loader rules in webpack.config.js ` +
+        `still match the current shape of the patched files.`,
+    );
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,17 @@ const config = {
         options: {
           multiple: [
             {
+              search: 'const require = createRequire(import.meta.url);',
+              replace: '',
+              strict: true,
+            },
+            {
+              search:
+                'const __dirname = path.resolve(fileURLToPath(import.meta.url), "..");',
+              replace: 'const __dirname = path.resolve(__filename, "..");',
+              strict: true,
+            },
+            {
               search:
                 'const imported = await import(path.isAbsolute(id) ? pathToFileURL(id).toString() : id);',
               replace:
@@ -84,6 +95,16 @@ const config = {
         loader: 'string-replace-loader',
         options: {
           multiple: [
+            {
+              search: 'const require = createRequire(import.meta.url);',
+              replace: '',
+              strict: true,
+            },
+            {
+              search: '        : import.meta.url);',
+              replace: '        : pathToFileURL(__filename));',
+              strict: true,
+            },
             {
               search: 'return require(id);',
               replace: 'return __non_webpack_require__(id);',


### PR DESCRIPTION
webpack.config.js string-replace-loader rules for @commitlint/load and @commitlint/resolve-extends missed three module-scope import.meta.url initializers introduced in v20 ESM migration:

- load-plugin.js:9  const require = createRequire(import.meta.url)
- load-plugin.js:10 const __dirname = path.resolve(fileURLToPath(import.meta.url), "..")
- resolve-extends/index.js:11 const require = createRequire(import.meta.url)
- resolve-extends/index.js:45 : import.meta.url) fallback in resolveFrom()

When webpack compiles these ESM files to CJS, import.meta.url becomes a synthetic webpack:// string that fileURLToPath/createRequire reject on Windows with "TypeError: File URL path must be absolute".

Patches: remove the unused const require declaration (replacing with __non_webpack_require__ caused a const require = require TDZ crash), replace fileURLToPath(import.meta.url) with __filename, and replace the import.meta.url URL fallback with pathToFileURL(__filename).

Also adds e2e-test/suite/bundle-check.test.ts — a Mocha test that greps dist/extension.js for import.meta.url and asserts zero matches, guarding against regression.

Fixes #383