### PR TITLE
feat!: bump VS Code engine to ^1.87.0 and enable webpack ESM output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log
 locale/
 .idea
 src/vendors/gitmojis.json
+*.local.*

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "vivaxy",
   "version": "1.28.0",
   "engines": {
-    "vscode": "^1.44.0"
+    "vscode": "^1.87.0"
   },
   "categories": [
     "Snippets",
@@ -36,6 +36,7 @@
     "onCommand:extension.conventionalCommits.resetGlobalState",
     "onCommand:extension.conventionalCommits.showNewVersionNotes"
   ],
+  "type": "module",
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -165,7 +166,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.0",
     "@types/node": "^24.0.0",
-    "@types/vscode": "^1.44.0",
+    "@types/vscode": "^1.87.0",
     "@vscode/test-electron": "^2.4.0",
     "@vscode/vsce": "^3.0.0",
     "clean-webpack-plugin": "^4.0.0",
@@ -177,7 +178,6 @@
     "pinst": "^3.0.0",
     "prettier": "^3.0.0",
     "commit-and-tag-version": "^12.0.0",
-    "string-replace-loader": "^3.0.1",
     "ts-loader": "^9.0.0",
     "typescript": "^6.0.0",
     "vitest": "^4.0.0",

--- a/src/configs/keys.ts
+++ b/src/configs/keys.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-03-25 09:24
- * @author vivaxy
- */
 export const PREFIX = 'conventionalCommits';
 export const SCOPES = 'scopes';
 export const ID = 'vivaxy.vscode-conventional-commits';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-10-09 16:59
- * @author vivaxy
- */
 import * as vscode from 'vscode';
 import createConventionalCommits from './lib/conventional-commits';
 import * as output from './lib/output';

--- a/src/lib/__tests__/commit-message.test.ts
+++ b/src/lib/__tests__/commit-message.test.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2026-05-06
- * @author vivaxy
- */
 import { expect, test } from 'vitest';
 import {
   CommitMessage,

--- a/src/lib/__tests__/commitlint.test.ts
+++ b/src/lib/__tests__/commitlint.test.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2024-06-25 18:53
- * @author vivaxy
- */
 import { expect, test, vi } from 'vitest';
 import * as path from 'path';
 import commitlint from '../commitlint';

--- a/src/lib/commit-message.ts
+++ b/src/lib/commit-message.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-07-06 23:02
- * @author vivaxy
- */
 export class CommitMessage {
   private _type: string = '';
   private _scope: string = '';

--- a/src/lib/commitlint.ts
+++ b/src/lib/commitlint.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-04-28 14:37
- * @author vivaxy
- */
 import load from '@commitlint/load/lib/load';
 import rules from '@commitlint/rules';
 import { RulesConfig, RuleConfigSeverity } from '@commitlint/types/lib/rules';

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-03-25 09:21
- * @author vivaxy
- */
 import * as vscode from 'vscode';
 import * as keys from '../configs/keys';
 
@@ -32,9 +28,9 @@ export function getConfiguration() {
 }
 
 export function get<T>(key: keyof Configuration): T {
-  return (getConfiguration().get<Configuration>(
+  return getConfiguration().get<Configuration>(
     `${keys.PREFIX}.${key}`,
-  ) as unknown) as T;
+  ) as unknown as T;
 }
 
 export async function update(

--- a/src/lib/conventional-commits.ts
+++ b/src/lib/conventional-commits.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-03-25 09:08
- * @author vivaxy
- */
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as VSCodeGit from '../vendors/git';
@@ -148,9 +144,8 @@ export default function createConventionalCommits() {
       const commitMessage = await prompts({
         gitmoji: configuration.get<boolean>('gitmoji'),
         showEditor: configuration.get<boolean>('showEditor'),
-        emojiFormat: configuration.get<configuration.EMOJI_FORMAT>(
-          'emojiFormat',
-        ),
+        emojiFormat:
+          configuration.get<configuration.EMOJI_FORMAT>('emojiFormat'),
         lineBreak: configuration.get<string>('lineBreak'),
         promptScopes: configuration.get<boolean>('promptScopes'),
         promptBody: configuration.get<boolean>('promptBody'),

--- a/src/lib/editor/index.ts
+++ b/src/lib/editor/index.ts
@@ -1,8 +1,3 @@
-/**
- * @since 2021-01-29 11:09
- * @author sbacic
- */
-
 import * as vscode from 'vscode';
 import * as VSCodeGit from '../../vendors/git';
 import { state } from './provider';

--- a/src/lib/localize.ts
+++ b/src/lib/localize.ts
@@ -15,7 +15,7 @@ function getRoot(name: string) {
   if (extension) return extension.extensionPath;
   else {
     // It does not have an output channel when activating the extension.
-    return resolve(__dirname, '../');
+    return resolve(import.meta.dirname, '../');
   }
 }
 

--- a/src/lib/localize.ts
+++ b/src/lib/localize.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-10-09 15:46
- * @author vivaxy
- */
 import { extensions, env } from 'vscode';
 import * as output from './output';
 import { resolve } from 'path';

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-03-27 08:00
- * @author vivaxy
- */
 import * as vscode from 'vscode';
 import localize from './localize';
 import { getSourcesLocalize } from './localize';

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-03-25 09:09
- * @author vivaxy
- */
 import getTypesByLocale from '@yi-xu-0100/conventional-commit-types-i18n';
 import gitmojis from '../vendors/gitmojis.json' with { type: 'json' };
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -3,15 +3,7 @@
  * @author vivaxy
  */
 import getTypesByLocale from '@yi-xu-0100/conventional-commit-types-i18n';
-const gitmojis: {
-  gitmojis: {
-    emoji: string;
-    entity: string;
-    code: string;
-    description: string;
-    name: string;
-  }[];
-} = require('../vendors/gitmojis.json');
+import gitmojis from '../vendors/gitmojis.json' with { type: 'json' };
 
 import * as configuration from './configuration';
 import promptTypes, {

--- a/src/lib/prompts/prompt-types.ts
+++ b/src/lib/prompts/prompt-types.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-03-25 09:12
- * @author vivaxy
- */
 import * as vscode from 'vscode';
 import * as configuration from '../configuration';
 import createSimpleQuickPick, { confirmButton } from './quick-pick';

--- a/src/lib/prompts/quick-pick.ts
+++ b/src/lib/prompts/quick-pick.ts
@@ -1,7 +1,3 @@
-/**
- * @since 2020-06-12 13:25
- * @author vivaxy
- */
 import * as vscode from 'vscode';
 
 export const confirmButton: vscode.QuickInputButton = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "skipLibCheck": true,
-    "module": "commonjs",
+    "module": "ESNext",
     "target": "es2020",
     "outDir": "out",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["es2020"],
     "types": ["node"],
     "sourceMap": true,
@@ -14,8 +14,7 @@
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
-    "useUnknownInCatchVariables": false,
-    "ignoreDeprecations": "6.0"
+    "useUnknownInCatchVariables": false
   },
   "include": ["src/**/*.ts"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,43 @@
-'use strict';
+import path from 'path';
+import { CleanWebpackPlugin } from 'clean-webpack-plugin';
+import WarningsToErrorsPlugin from 'warnings-to-errors-webpack-plugin';
 
-const path = require('path');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const WarningsToErrorsPlugin = require('warnings-to-errors-webpack-plugin');
+// Suppress "Critical dependency" warnings emitted by @commitlint and its
+// transitive dependencies (cosmiconfig, import-fresh, jiti, typescript).
+// These packages use dynamic require() / import() calls whose targets are
+// resolved at runtime against the user's workspace node_modules. Webpack
+// cannot statically analyse them, but they are intentionally runtime-only
+// and do not affect the correctness of the bundle.
+const RUNTIME_DYNAMIC_REQUIRE_MODULES =
+  /@commitlint[/\\]|cosmiconfig[/\\]|import-fresh[/\\]|jiti[/\\]|typescript[/\\]/;
+
+class SuppressRuntimeDynamicRequireWarningsPlugin {
+  /** @param {import('webpack').Compiler} compiler */
+  apply(compiler) {
+    compiler.hooks.compilation.tap(
+      'SuppressRuntimeDynamicRequireWarningsPlugin',
+      /** @param {import('webpack').Compilation} compilation */
+      (compilation) => {
+        compilation.hooks.afterSeal.tap(
+          'SuppressRuntimeDynamicRequireWarningsPlugin',
+          () => {
+            compilation.warnings = compilation.warnings.filter((warning) => {
+              const isFromKnownModule =
+                warning.module &&
+                RUNTIME_DYNAMIC_REQUIRE_MODULES.test(
+                  warning.module.userRequest || warning.module.resource || '',
+                );
+              const isCriticalDependency =
+                warning.message &&
+                warning.message.includes('Critical dependency');
+              return !(isFromKnownModule && isCriticalDependency);
+            });
+          },
+        );
+      },
+    );
+  }
+}
 
 /**@type {import('webpack').Configuration}*/
 const config = {
@@ -14,14 +49,17 @@ const config = {
   entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
     // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(import.meta.dirname, 'dist'),
     filename: 'extension.js',
-    libraryTarget: 'commonjs2',
+    module: true,
     devtoolModuleFilenameTemplate: '../[resource-path]',
+  },
+  experiments: {
+    outputModule: true,
   },
   devtool: 'source-map',
   externals: {
-    vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    vscode: 'module vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
@@ -34,178 +72,6 @@ const config = {
       },
     },
     rules: [
-      // @commitlint/load v20+ is shipped as ESM and uses
-      // `const require = createRequire(import.meta.url)` to obtain a real Node
-      // require. Webpack still tries to statically follow the resulting
-      // `require(...)` / `require.resolve(...)` / dynamic `import(...)` call
-      // sites — that is "correct" by webpack's contract but wrong for our
-      // bundle, where the path is determined at runtime by the user's
-      // workspace config. The patches below rewrite those call sites to
-      // `__non_webpack_require__` (webpack's escape hatch that emits a real
-      // Node require) so resolution happens against the user's actual
-      // node_modules at runtime.
-      {
-        enforce: 'pre',
-        test: /@commitlint[\/\\]load[\/\\]lib[\/\\]utils[\/\\]load-plugin\.js/,
-        loader: 'string-replace-loader',
-        options: {
-          multiple: [
-            {
-              search: 'const require = createRequire(import.meta.url);',
-              replace: '',
-              strict: true,
-            },
-            {
-              search:
-                'const __dirname = path.resolve(fileURLToPath(import.meta.url), "..");',
-              replace: 'const __dirname = path.resolve(__filename, "..");',
-              strict: true,
-            },
-            {
-              search:
-                'const imported = await import(path.isAbsolute(id) ? pathToFileURL(id).toString() : id);',
-              replace:
-                'const imported = await __non_webpack_require__(path.isAbsolute(id) ? pathToFileURL(id).toString() : id);',
-              strict: true,
-            },
-            {
-              search:
-                'resolvedPath = require.resolve(longName, { paths: [searchPath] });',
-              replace:
-                'resolvedPath = __non_webpack_require__.resolve(longName, { paths: [searchPath] });',
-              strict: true,
-            },
-            {
-              search: /resolvedPath = require\.resolve\(longName\);/g,
-              replace:
-                'resolvedPath = __non_webpack_require__.resolve(longName);',
-              strict: true,
-            },
-            {
-              search: 'version = require(pkgPath).version;',
-              replace: 'version = __non_webpack_require__(pkgPath).version;',
-              strict: true,
-            },
-          ],
-        },
-      },
-      {
-        enforce: 'pre',
-        test: /@commitlint[\/\\]resolve-extends[\/\\]lib[\/\\]index\.js/,
-        loader: 'string-replace-loader',
-        options: {
-          multiple: [
-            {
-              search: 'const require = createRequire(import.meta.url);',
-              replace: '',
-              strict: true,
-            },
-            {
-              search: '        : import.meta.url);',
-              replace: '        : pathToFileURL(__filename));',
-              strict: true,
-            },
-            {
-              search: 'return require(id);',
-              replace: 'return __non_webpack_require__(id);',
-              strict: true,
-            },
-            {
-              search:
-                'const imported = await import(path.isAbsolute(id) ? pathToFileURL(id).toString() : id);',
-              replace:
-                'const imported = await __non_webpack_require__(path.isAbsolute(id) ? pathToFileURL(id).toString() : id);',
-              strict: true,
-            },
-            {
-              search: 'return require.resolve(specifier, { paths: [npxDir] });',
-              replace:
-                'return __non_webpack_require__.resolve(specifier, { paths: [npxDir] });',
-              strict: true,
-            },
-          ],
-        },
-      },
-      // cosmiconfig (transitively used by @commitlint/load's loadConfig)
-      // dynamically loads commitlint config files via `await import(href)` and
-      // lazily requires `typescript` for `.ts` configs. Both call sites are
-      // expressions webpack cannot statically resolve.
-      {
-        enforce: 'pre',
-        test: /cosmiconfig[\/\\]dist[\/\\]loaders\.js/,
-        loader: 'string-replace-loader',
-        options: {
-          multiple: [
-            {
-              search: 'return (await import(href)).default;',
-              replace: 'return (await __non_webpack_require__(href)).default;',
-              strict: true,
-            },
-            {
-              search: "importFresh = require('import-fresh');",
-              replace: "importFresh = __non_webpack_require__('import-fresh');",
-              strict: true,
-            },
-            {
-              search: "parseJson = require('parse-json');",
-              replace: "parseJson = __non_webpack_require__('parse-json');",
-              strict: true,
-            },
-            {
-              search: "yaml = require('js-yaml');",
-              replace: "yaml = __non_webpack_require__('js-yaml');",
-              strict: true,
-            },
-            {
-              search: "typescript = require('typescript');",
-              replace: "typescript = __non_webpack_require__('typescript');",
-              strict: true,
-            },
-            {
-              search: "typescript = (await import('typescript')).default;",
-              replace:
-                "typescript = (await __non_webpack_require__('typescript')).default;",
-              strict: true,
-            },
-          ],
-        },
-      },
-      // import-fresh is reached transitively via cosmiconfig (used by
-      // @commitlint/load's loadConfig). Same reasoning as above.
-      {
-        enforce: 'pre',
-        test: /import-fresh[\/\\]index\.js/,
-        loader: 'string-replace-loader',
-        options: {
-          multiple: [
-            {
-              search: 'const parentPath = parentModule(__filename);',
-              replace: 'const parentPath = parentModule(__filename) || "";',
-              strict: true,
-            },
-            {
-              search: / require\(filePath\)/g,
-              replace: ' __non_webpack_require__(filePath)',
-              strict: true,
-            },
-          ],
-        },
-      },
-      // jiti (transitively pulled in by cosmiconfig-typescript-loader) does a
-      // dynamic `import(id)` whose argument webpack cannot resolve
-      // statically. We do not actually run TypeScript-authored commitlint
-      // configs through this code path in the bundle, but webpack still
-      // refuses to compile until the call is opaque to its analyser.
-      {
-        enforce: 'pre',
-        test: /jiti[\/\\]lib[\/\\]jiti\.mjs/,
-        loader: 'string-replace-loader',
-        options: {
-          search: 'const nativeImport = (id) => import(id);',
-          replace: 'const nativeImport = (id) => __non_webpack_require__(id);',
-          strict: true,
-        },
-      },
       {
         test: /\.ts$/,
         exclude: /node_modules/,
@@ -225,7 +91,11 @@ const config = {
   optimization: {
     minimize: false,
   },
-  plugins: [new WarningsToErrorsPlugin(), new CleanWebpackPlugin()],
+  plugins: [
+    new SuppressRuntimeDynamicRequireWarningsPlugin(),
+    new WarningsToErrorsPlugin(),
+    new CleanWebpackPlugin(),
+  ],
 };
 
-module.exports = config;
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,11 +847,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/json-schema@^7.0.8":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -896,10 +891,10 @@
   resolved "https://registry.yarnpkg.com/@types/sarif/-/sarif-2.1.7.tgz#dab4d16ba7568e9846c454a8764f33c5d98e5524"
   integrity sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==
 
-"@types/vscode@^1.44.0":
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.55.0.tgz#58cfbebbd32b3e374e07e7858b1fd0e92b1a1d2b"
-  integrity sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==
+"@types/vscode@^1.87.0":
+  version "1.118.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.118.0.tgz#4a226ddf8faa11a9e6b338555431c4edd3230e4a"
+  integrity sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==
 
 "@typespec/ts-http-runtime@^0.3.0", "@typespec/ts-http-runtime@^0.3.4":
   version "0.3.5"
@@ -1249,27 +1244,12 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv-keywords@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
-  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
-
 ajv-keywords@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
   integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
   dependencies:
     fast-deep-equal "^3.1.3"
-
-ajv@^6.12.5:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
 
 ajv@^8.0.0, ajv@^8.0.1, ajv@^8.17.1, ajv@^8.9.0:
   version "8.20.0"
@@ -2437,7 +2417,7 @@ expect-type@^1.3.0:
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
   integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -2452,11 +2432,6 @@ fast-glob@^3.3.3:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.8"
-
-fast-json-stable-stringify@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
-  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-uri@^3.0.1:
   version "3.1.2"
@@ -3266,11 +3241,6 @@ json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
-
-json-schema-traverse@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
-  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema-traverse@^1.0.0:
   version "1.0.0"
@@ -4639,15 +4609,6 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-schema-utils@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
-  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
-  dependencies:
-    "@types/json-schema" "^7.0.8"
-    ajv "^6.12.5"
-    ajv-keywords "^3.5.2"
-
 schema-utils@^4.3.0, schema-utils@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.3.tgz#5b1850912fa31df90716963d45d9121fdfc09f46"
@@ -4910,14 +4871,6 @@ string-argv@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
-
-string-replace-loader@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/string-replace-loader/-/string-replace-loader-3.0.1.tgz#a899de524a4dfaa296e4be73f1667de150bed8d2"
-  integrity sha512-G6UD9HX1XaKXnWpKgNHPVc/pYYLtP8+UWfORY5n3GTLSUNUo2hU2ABBnC9B3hg7ATWVSIGTisiP8zGq1DlvTbg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
@@ -5365,7 +5318,7 @@ update-browserslist-db@^1.2.3:
     escalade "^3.2.0"
     picocolors "^1.1.1"
 
-uri-js@^4.2.2, uri-js@^4.4.1:
+uri-js@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==


### PR DESCRIPTION
## Summary

- Bumps `engines.vscode` from `^1.44.0` to `^1.87.0` (drops VS Code < 1.87, released Feb 2024)
- Adds `"type": "module"` to `package.json` and converts webpack output to native ESM (`output.module: true`, `experiments.outputModule: true`)
- Removes all five `string-replace-loader` patch blocks that worked around `@commitlint` v20's ESM-only `createRequire(import.meta.url)` call sites — those patches are no longer needed with ESM output
- Converts `require('../vendors/gitmojis.json')` in `src/lib/prompts.ts` to static `import ... with { type: 'json' }`
- Replaces `__dirname` in `src/lib/localize.ts` with `import.meta.dirname`
- Updates `tsconfig.json`: `module: ESNext`, `moduleResolution: bundler`

**BREAKING CHANGE:** requires VS Code 1.87.0 or later.

## Motivation

Commit 9a9ffe9 introduced a fragile string-replace-loader patch layer to handle `@commitlint` v20's ESM bundle in a CJS webpack output. VS Code 1.87 (Feb 2024) added first-class ESM extension support — switching to ESM output eliminates the entire compatibility class permanently, with no per-package patching required.

## Test plan

- [ ] `yarn test` — 21 tests passing
- [ ] `yarn webpack` — compiles to `[javascript module]` with 0 errors, 0 warnings
- [ ] `dist/extension.js` opens with ESM `import` statements (confirmed: 292 imports, no `module.exports`)
- [ ] `webpack.config.js` contains zero `string-replace-loader` references