### PR TITLE
fix: convert prepare.js require() to ESM import syntax

### DIFF
--- a/prepare.js
+++ b/prepare.js
@@ -1,6 +1,6 @@
 // download latest gitmojis.json
-const https = require('https');
-const fs = require('fs');
+import https from 'node:https';
+import fs from 'node:fs';
 
 const file = fs.createWriteStream('./src/vendors/gitmojis.json');
 const request = https.get(


### PR DESCRIPTION
## Summary

- `package.json` sets `"type": "module"` (added in `feat/esm-output`), so Node 24 treats all `.js` files as ESM
- `prepare.js` used `require('https')` and `require('fs')` — invalid in ESM scope
- Replace both with `import` statements using the `node:` protocol prefix

## Test plan

- [x] `node prepare.js` exits cleanly and writes `src/vendors/gitmojis.json` (73 entries)
- [x] `yarn test` — 21 tests passing
- [ ] `yarn build` — verify CI passes