### PR TITLE
fix(bundle): stop redirecting cosmiconfig bundled deps to __non_webpack_require__

### DIFF
--- a/e2e-test/suite/bundle-check.test.ts
+++ b/e2e-test/suite/bundle-check.test.ts
@@ -34,4 +34,46 @@ suite('bundle sanity checks', () => {
         `still match the current shape of the patched files.`,
     );
   });
+
+  // Regression test for issue #391: cosmiconfig v9 lazy-requires parse-json
+  // and js-yaml. These must be bundled by webpack (__webpack_require__), not
+  // redirected to __non_webpack_require__ which would fail at runtime because
+  // no node_modules/ is shipped inside the vsix.
+  test('dist/extension.js bundles parse-json via __webpack_require__ (issue #391 regression)', () => {
+    const source = fs.readFileSync(bundlePath, 'utf8');
+
+    // parse-json must appear as a webpack module path, not a bare runtime require.
+    assert.ok(
+      source.includes('parse-json'),
+      'dist/extension.js must contain parse-json (it should be bundled)',
+    );
+    // The lazy-require call that previously escaped bundling must now resolve
+    // through webpack. A bare require('parse-json') with no webpack module id
+    // would mean it escaped.
+    const bareRequire = /\brequire\(['"]parse-json['"]\)/.test(source);
+    assert.strictEqual(
+      bareRequire,
+      false,
+      `dist/extension.js must not contain a bare require('parse-json') — ` +
+        `it must be bundled as a __webpack_require__ call instead. ` +
+        `Check the cosmiconfig string-replace-loader rule in webpack.config.js.`,
+    );
+  });
+
+  test('dist/extension.js bundles js-yaml via __webpack_require__ (issue #391 regression)', () => {
+    const source = fs.readFileSync(bundlePath, 'utf8');
+
+    assert.ok(
+      source.includes('js-yaml'),
+      'dist/extension.js must contain js-yaml (it should be bundled)',
+    );
+    const bareRequire = /\brequire\(['"]js-yaml['"]\)/.test(source);
+    assert.strictEqual(
+      bareRequire,
+      false,
+      `dist/extension.js must not contain a bare require('js-yaml') — ` +
+        `it must be bundled as a __webpack_require__ call instead. ` +
+        `Check the cosmiconfig string-replace-loader rule in webpack.config.js.`,
+    );
+  });
 });

--- a/e2e-test/suite/conventional-commits.test.ts
+++ b/e2e-test/suite/conventional-commits.test.ts
@@ -16,6 +16,7 @@
 
 import * as assert from 'assert';
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
@@ -401,6 +402,106 @@ suite('extension.conventionalCommits e2e', () => {
       stubs.remaining(),
       0,
       `all scripted prompt answers should have been consumed; remaining=${stubs.remaining()}`,
+    );
+  });
+
+  // Regression test for issue #391: cosmiconfig v9 lazy-requires parse-json
+  // to load JSON commitlint configs. If parse-json is not bundled correctly,
+  // loadRuleConfigs silently falls back to {} and the custom type-enum is
+  // invisible — the stub would pick the first default type instead of
+  // the JSON-defined type, causing the commit message assertion to fail.
+  test('loads type-enum from a JSON commitlintrc (issue #391 regression)', async function () {
+    this.timeout(60000);
+
+    // Write a .commitlintrc.json that defines a single custom type so we can
+    // unambiguously detect whether cosmiconfig parsed it via parse-json.
+    const commitlintrcPath = path.join(repoPath, '.commitlintrc.json');
+    const jsonConfig = JSON.stringify({
+      rules: {
+        'type-enum': [2, 'always', ['json-fix']],
+      },
+    });
+    fs.writeFileSync(commitlintrcPath, jsonConfig, 'utf8');
+
+    let localCapturedValue: string | undefined;
+
+    try {
+      // Prompt order matches default settings (gitmoji on, scope on, ci off,
+      // body on, footer on, showEditor off):
+      //   1. type     QuickPick  → 'json-fix'  (only present if JSON was parsed)
+      //   2. scope    QuickPick  → ''           (no scope)
+      //   3. gitmoji  QuickPick  → ''           (no gitmoji)
+      //   4. subject  InputBox   → 'json commitlintrc loaded'
+      //   5. body     InputBox   → ''
+      //   6. footer   InputBox   → ''
+      stubs = installPromptStubs([
+        'json-fix',
+        '',
+        '',
+        'json commitlintrc loaded',
+        '',
+        '',
+      ]);
+
+      const trackedFileUri = vscode.Uri.file(path.join(repoPath, 'README.md'));
+      const newContents = Buffer.from(
+        '# E2E mock repo\n\njson-config edit ' + Date.now() + '\n',
+        'utf8',
+      );
+      await vscode.workspace.fs.writeFile(trackedFileUri, newContents);
+      await repository.add([trackedFileUri.fsPath]);
+
+      // Capture inputBox.value with a simple own-property trap on the current
+      // inputBox object (lighter than the full prototype dance in the main test).
+      const inputBoxRef = repository.inputBox as { value: string };
+      const valueOwner: object = ((): object => {
+        let cur: object | null = inputBoxRef;
+        while (cur) {
+          if (Object.prototype.hasOwnProperty.call(cur, 'value')) return cur;
+          cur = Object.getPrototypeOf(cur);
+        }
+        return inputBoxRef;
+      })();
+      const origDescriptor = Object.getOwnPropertyDescriptor(
+        valueOwner,
+        'value',
+      );
+      if (origDescriptor) {
+        const origSet = origDescriptor.set;
+        const origGet = origDescriptor.get;
+        Object.defineProperty(valueOwner, 'value', {
+          configurable: true,
+          enumerable: origDescriptor.enumerable,
+          get() {
+            return origGet ? origGet.call(this) : undefined;
+          },
+          set(next: string) {
+            if (typeof next === 'string' && next !== '') {
+              localCapturedValue = next;
+            }
+            if (origSet) origSet.call(this, next);
+          },
+        });
+      }
+
+      await vscode.commands.executeCommand(COMMAND_ID, repository.rootUri);
+    } finally {
+      fs.unlinkSync(commitlintrcPath);
+    }
+
+    console.log(
+      '[e2e diagnostic] json-config capturedInputBoxValue:',
+      JSON.stringify(localCapturedValue),
+    );
+
+    // The commit message must use the JSON-defined type 'json-fix', proving
+    // cosmiconfig successfully loaded the .commitlintrc.json via parse-json.
+    const expectedMessage = 'json-fix: json commitlintrc loaded';
+    assert.strictEqual(
+      localCapturedValue,
+      expectedMessage,
+      `repository.inputBox.value should be ${JSON.stringify(expectedMessage)} ` +
+        `— if it starts with a default type like 'feat', parse-json was not bundled`,
     );
   });
 });

--- a/src/lib/__tests__/commitlint.test.ts
+++ b/src/lib/__tests__/commitlint.test.ts
@@ -29,3 +29,19 @@ test('should load commitlint@v19.3.1', async function () {
   );
   expect(commitlint.getTypeEnum()).toStrictEqual(['bar']);
 });
+
+// Regression tests for issue #391: cosmiconfig v9 lazy-requires parse-json and
+// js-yaml. These must be bundled by webpack, not redirected to __non_webpack_require__.
+test('should load JSON config (exercises cosmiconfig parse-json)', async function () {
+  await commitlint.loadRuleConfigs(
+    path.join(fixtureRootPath, 'should-load-json-config'),
+  );
+  expect(commitlint.getTypeEnum()).toStrictEqual(['json-type']);
+});
+
+test('should load YAML config (exercises cosmiconfig js-yaml)', async function () {
+  await commitlint.loadRuleConfigs(
+    path.join(fixtureRootPath, 'should-load-yaml-config'),
+  );
+  expect(commitlint.getTypeEnum()).toStrictEqual(['yaml-type']);
+});

--- a/src/lib/__tests__/fixtures/should-load-json-config/.commitlintrc.json
+++ b/src/lib/__tests__/fixtures/should-load-json-config/.commitlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "type-enum": [2, "always", ["json-type"]]
+  }
+}

--- a/src/lib/__tests__/fixtures/should-load-yaml-config/.commitlintrc.yaml
+++ b/src/lib/__tests__/fixtures/should-load-yaml-config/.commitlintrc.yaml
@@ -1,0 +1,5 @@
+rules:
+  type-enum:
+    - 2
+    - always
+    - - yaml-type

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -127,9 +127,13 @@ const config = {
         },
       },
       // cosmiconfig (transitively used by @commitlint/load's loadConfig)
-      // dynamically loads commitlint config files via `await import(href)` and
-      // lazily requires `typescript` for `.ts` configs. Both call sites are
-      // expressions webpack cannot statically resolve.
+      // dynamically loads commitlint config files via `await import(href)` where
+      // href is a runtime file:// URL pointing to the user's workspace config.
+      // Webpack cannot statically resolve this, so we redirect it to
+      // __non_webpack_require__ so Node resolves it at runtime.
+      // typescript is a workspace dep that must also resolve at runtime.
+      // parse-json, js-yaml, and import-fresh are cosmiconfig's own bundled deps
+      // and must NOT be redirected — webpack bundles them normally.
       {
         enforce: 'pre',
         test: /cosmiconfig[\/\\]dist[\/\\]loaders\.js/,
@@ -139,21 +143,6 @@ const config = {
             {
               search: 'return (await import(href)).default;',
               replace: 'return (await __non_webpack_require__(href)).default;',
-              strict: true,
-            },
-            {
-              search: "importFresh = require('import-fresh');",
-              replace: "importFresh = __non_webpack_require__('import-fresh');",
-              strict: true,
-            },
-            {
-              search: "parseJson = require('parse-json');",
-              replace: "parseJson = __non_webpack_require__('parse-json');",
-              strict: true,
-            },
-            {
-              search: "yaml = require('js-yaml');",
-              replace: "yaml = __non_webpack_require__('js-yaml');",
               strict: true,
             },
             {


### PR DESCRIPTION
## Summary

- Fixes #391: `Cannot find module 'parse-json'` on extension startup in 1.28.1
- Removes `parse-json`, `js-yaml`, and `import-fresh` from the cosmiconfig `string-replace-loader` patch — these are cosmiconfig's own bundled deps and must be included in the webpack bundle, not redirected to `__non_webpack_require__`
- Only `typescript` (user workspace dep) and `import(href)` (user config file URL) legitimately need `__non_webpack_require__`

## Root cause

`@commitlint/load` v20 pulled in cosmiconfig v9, which lazy-requires `parse-json`, `js-yaml`, and `import-fresh`. The webpack patch introduced in 1.28.1 incorrectly redirected all cosmiconfig lazy-requires to `__non_webpack_require__`, preventing webpack from bundling them. At runtime the vsix ships no `node_modules/`, so `require('parse-json')` fails.

## Test plan

- [x] Unit test: `should load JSON config` — loads `.commitlintrc.json` fixture via cosmiconfig, asserts type enum from `parse-json` path
- [x] Unit test: `should load YAML config` — loads `.commitlintrc.yaml` fixture via cosmiconfig, asserts type enum from `js-yaml` path
- [x] E2e bundle check: `bundles parse-json via __webpack_require__` — asserts no bare `require('parse-json')` in `dist/extension.js`
- [x] E2e bundle check: `bundles js-yaml via __webpack_require__` — same for `js-yaml`
- [x] E2e runtime: `loads type-enum from a JSON commitlintrc` — writes `.commitlintrc.json` into mock repo, drives full extension flow, asserts commit message uses JSON-defined type `json-fix`