### PR TITLE
fix(bundle): fix TypeError: createRequire is not a function for TypeScript commitlint configs (#395)

### DIFF
--- a/e2e-test/suite/bundle-check.test.ts
+++ b/e2e-test/suite/bundle-check.test.ts
@@ -77,34 +77,39 @@ suite('bundle sanity checks', () => {
     );
   });
 
-  // Regression test for issue #395: jiti/lib/jiti.cjs calls
-  // `require("node:module")` to obtain `createRequire`. webpack must NOT
-  // inline node:module as an empty stub — instead the string-replace-loader
-  // rule in webpack.config.js rewrites the call to
-  // `__non_webpack_require__("node:module")` so Node resolves the real
-  // built-in at runtime. Without this patch, `createRequire` is undefined and
-  // cosmiconfig-typescript-loader throws
-  // `TypeError: i.createRequire is not a function` for any workspace that
-  // contains a TypeScript commitlint config.
-  test('dist/extension.js does not contain bare require("node:module") in jiti.cjs context (issue #395 regression)', () => {
+  // Regression test for issue #395: jiti/lib/jiti.mjs and jiti/lib/jiti.cjs
+  // both call into node:module to obtain `createRequire`. Without the
+  // string-replace-loader patches in webpack.config.js, webpack either drops
+  // the ESM import (leaving createRequire undefined) or bundles node:module as
+  // an empty stub. Either way `createJiti` receives createRequire: undefined
+  // and cosmiconfig-typescript-loader throws
+  // `TypeError: i.createRequire is not a function` for TypeScript commitlint configs.
+  //
+  // The fix patches both jiti entries to use __non_webpack_require__("node:module"),
+  // which webpack emits as `require("node:module")` resolved via the
+  // "node:module" external entry — i.e. `module.exports = require("node:module")`.
+  // The correct signal is therefore that "node:module" IS present as a webpack
+  // external, and that createRequire is not undefined in createJiti's call.
+  test('dist/extension.js externalises node:module and passes createRequire to createJiti (issue #395 regression)', () => {
     const source = fs.readFileSync(bundlePath, 'utf8');
 
-    // The patched line `const { createRequire } = require("node:module");`
-    // must not survive into the bundle verbatim.  After patching,
-    // `__non_webpack_require__("node:module")` is emitted instead, which
-    // webpack externalises as the real Node built-in.
-    const unpatched =
-      /const\s*\{\s*createRequire\s*\}\s*=\s*require\(["']node:module["']\)/.test(
-        source,
-      );
-    assert.strictEqual(
-      unpatched,
-      false,
-      `dist/extension.js must not contain the unpatched ` +
-        `\`const { createRequire } = require("node:module")\` from jiti.cjs — ` +
-        `it means the string-replace-loader rule for jiti/lib/jiti.cjs in ` +
-        `webpack.config.js no longer matches (issue #395). ` +
-        `Check that the search string still matches the current jiti version.`,
+    // 1. node:module must be present as a webpack external so that
+    //    require("node:module") resolves to the real Node built-in at runtime.
+    assert.ok(
+      source.includes('!*** external "node:module" ***!'),
+      `dist/extension.js must contain a webpack external for "node:module" — ` +
+        `without it, require("node:module") resolves to an empty stub and ` +
+        `createRequire is undefined (issue #395).`,
+    );
+
+    // 2. createJiti must not receive `createRequire: undefined`. After patching,
+    //    the jiti.mjs module passes the variable `createRequire` (obtained from
+    //    node:module) rather than the literal `undefined`.
+    assert.ok(
+      !source.includes('/* createRequire */ undefined'),
+      `dist/extension.js must not contain \`/* createRequire */ undefined\` — ` +
+        `this indicates the import { createRequire } from "node:module" in jiti.mjs ` +
+        `was dropped by webpack and the string-replace-loader patch is missing (issue #395).`,
     );
   });
 });

--- a/e2e-test/suite/bundle-check.test.ts
+++ b/e2e-test/suite/bundle-check.test.ts
@@ -76,4 +76,35 @@ suite('bundle sanity checks', () => {
         `Check the cosmiconfig string-replace-loader rule in webpack.config.js.`,
     );
   });
+
+  // Regression test for issue #395: jiti/lib/jiti.cjs calls
+  // `require("node:module")` to obtain `createRequire`. webpack must NOT
+  // inline node:module as an empty stub — instead the string-replace-loader
+  // rule in webpack.config.js rewrites the call to
+  // `__non_webpack_require__("node:module")` so Node resolves the real
+  // built-in at runtime. Without this patch, `createRequire` is undefined and
+  // cosmiconfig-typescript-loader throws
+  // `TypeError: i.createRequire is not a function` for any workspace that
+  // contains a TypeScript commitlint config.
+  test('dist/extension.js does not contain bare require("node:module") in jiti.cjs context (issue #395 regression)', () => {
+    const source = fs.readFileSync(bundlePath, 'utf8');
+
+    // The patched line `const { createRequire } = require("node:module");`
+    // must not survive into the bundle verbatim.  After patching,
+    // `__non_webpack_require__("node:module")` is emitted instead, which
+    // webpack externalises as the real Node built-in.
+    const unpatched =
+      /const\s*\{\s*createRequire\s*\}\s*=\s*require\(["']node:module["']\)/.test(
+        source,
+      );
+    assert.strictEqual(
+      unpatched,
+      false,
+      `dist/extension.js must not contain the unpatched ` +
+        `\`const { createRequire } = require("node:module")\` from jiti.cjs — ` +
+        `it means the string-replace-loader rule for jiti/lib/jiti.cjs in ` +
+        `webpack.config.js no longer matches (issue #395). ` +
+        `Check that the search string still matches the current jiti version.`,
+    );
+  });
 });

--- a/e2e-test/suite/conventional-commits.test.ts
+++ b/e2e-test/suite/conventional-commits.test.ts
@@ -504,4 +504,105 @@ suite('extension.conventionalCommits e2e', () => {
         `— if it starts with a default type like 'feat', parse-json was not bundled`,
     );
   });
+
+  // Regression test for issue #395: cosmiconfig-typescript-loader calls
+  // require("jiti") which resolves to jiti/lib/jiti.cjs. That file uses
+  // `require("node:module")` to obtain `createRequire`. Without the
+  // string-replace-loader patch in webpack.config.js, webpack stubs out
+  // node:module and `createRequire` is undefined, causing
+  // `TypeError: i.createRequire is not a function` before the prompt opens.
+  test('loads type-enum from a TypeScript commitlintrc (issue #395 regression)', async function () {
+    this.timeout(60000);
+
+    // Write a .commitlintrc.ts that defines a single custom type so we can
+    // unambiguously detect whether cosmiconfig parsed it via jiti.
+    const commitlintrcPath = path.join(repoPath, '.commitlintrc.ts');
+    fs.writeFileSync(
+      commitlintrcPath,
+      `export default { rules: { 'type-enum': [2, 'always', ['ts-fix']] } };\n`,
+      'utf8',
+    );
+
+    let localCapturedValue: string | undefined;
+
+    try {
+      // Prompt order matches default settings (gitmoji on, scope on, ci off,
+      // body on, footer on, showEditor off):
+      //   1. type     QuickPick  → 'ts-fix'  (only present if TS was parsed)
+      //   2. scope    QuickPick  → ''         (no scope)
+      //   3. gitmoji  QuickPick  → ''         (no gitmoji)
+      //   4. subject  InputBox   → 'ts commitlintrc loaded'
+      //   5. body     InputBox   → ''
+      //   6. footer   InputBox   → ''
+      stubs = installPromptStubs([
+        'ts-fix',
+        '',
+        '',
+        'ts commitlintrc loaded',
+        '',
+        '',
+      ]);
+
+      const trackedFileUri = vscode.Uri.file(path.join(repoPath, 'README.md'));
+      const newContents = Buffer.from(
+        '# E2E mock repo\n\nts-config edit ' + Date.now() + '\n',
+        'utf8',
+      );
+      await vscode.workspace.fs.writeFile(trackedFileUri, newContents);
+      await repository.add([trackedFileUri.fsPath]);
+
+      const inputBoxRef = repository.inputBox as { value: string };
+      const valueOwner: object = ((): object => {
+        let cur: object | null = inputBoxRef;
+        while (cur) {
+          if (Object.prototype.hasOwnProperty.call(cur, 'value')) return cur;
+          cur = Object.getPrototypeOf(cur);
+        }
+        return inputBoxRef;
+      })();
+      const origDescriptor = Object.getOwnPropertyDescriptor(
+        valueOwner,
+        'value',
+      );
+      if (origDescriptor) {
+        const origSet = origDescriptor.set;
+        const origGet = origDescriptor.get;
+        Object.defineProperty(valueOwner, 'value', {
+          configurable: true,
+          enumerable: origDescriptor.enumerable,
+          get() {
+            return origGet ? origGet.call(this) : undefined;
+          },
+          set(next: string) {
+            if (typeof next === 'string' && next !== '') {
+              localCapturedValue = next;
+            }
+            if (origSet) origSet.call(this, next);
+          },
+        });
+      }
+
+      await vscode.commands.executeCommand(COMMAND_ID, repository.rootUri);
+    } finally {
+      fs.unlinkSync(commitlintrcPath);
+    }
+
+    console.log(
+      '[e2e diagnostic] ts-config capturedInputBoxValue:',
+      JSON.stringify(localCapturedValue),
+    );
+
+    // The commit message must use the TS-defined type 'ts-fix', proving
+    // cosmiconfig-typescript-loader + jiti.cjs + createRequire all worked.
+    // If this throws "TypeError: i.createRequire is not a function" the
+    // string-replace-loader patch for jiti.cjs in webpack.config.js is missing.
+    const expectedMessage = 'ts-fix: ts commitlintrc loaded';
+    assert.strictEqual(
+      localCapturedValue,
+      expectedMessage,
+      `repository.inputBox.value should be ${JSON.stringify(expectedMessage)} ` +
+        `— if undefined, jiti.cjs threw createRequire is not a function (issue #395); ` +
+        `if it starts with a default type like 'feat', the TS config was not parsed`,
+    );
+  });
 });

--- a/src/lib/__tests__/commitlint.test.ts
+++ b/src/lib/__tests__/commitlint.test.ts
@@ -45,3 +45,14 @@ test('should load YAML config (exercises cosmiconfig js-yaml)', async function (
   );
   expect(commitlint.getTypeEnum()).toStrictEqual(['yaml-type']);
 });
+
+// Regression test for issue #395: jiti.cjs passes createRequire from node:module
+// to _createJiti; webpack must not bundle node:module as a stub (TypeError: i.createRequire
+// is not a function). Vitest runs un-bundled source, exercising the real jiti.cjs →
+// node:module → createRequire chain directly.
+test('should load TypeScript config (regression for issue #395 / jiti.cjs createRequire)', async function () {
+  await commitlint.loadRuleConfigs(
+    path.join(fixtureRootPath, 'should-load-ts-config'),
+  );
+  expect(commitlint.getTypeEnum()).toStrictEqual(['ts-type']);
+});

--- a/src/lib/__tests__/fixtures/should-load-ts-config/.commitlintrc.ts
+++ b/src/lib/__tests__/fixtures/should-load-ts-config/.commitlintrc.ts
@@ -1,0 +1,5 @@
+export default {
+  rules: {
+    'type-enum': [2, 'always', ['ts-type']],
+  },
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -195,6 +195,23 @@ const config = {
           strict: true,
         },
       },
+      // jiti/lib/jiti.cjs is the CJS entry reached via
+      // cosmiconfig-typescript-loader → require("jiti"). It calls
+      // require("node:module") to obtain createRequire, but node:module is not
+      // externalized in webpack, so it would be bundled as an empty stub and
+      // createRequire would be undefined at runtime. Rewrite the call to
+      // __non_webpack_require__ so Node resolves the real built-in at runtime.
+      {
+        enforce: 'pre',
+        test: /jiti[\/\\]lib[\/\\]jiti\.cjs/,
+        loader: 'string-replace-loader',
+        options: {
+          search: 'const { createRequire } = require("node:module");',
+          replace:
+            'const { createRequire } = __non_webpack_require__("node:module");',
+          strict: true,
+        },
+      },
       {
         test: /\.ts$/,
         exclude: /node_modules/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -180,19 +180,32 @@ const config = {
           ],
         },
       },
-      // jiti (transitively pulled in by cosmiconfig-typescript-loader) does a
-      // dynamic `import(id)` whose argument webpack cannot resolve
-      // statically. We do not actually run TypeScript-authored commitlint
-      // configs through this code path in the bundle, but webpack still
-      // refuses to compile until the call is opaque to its analyser.
+      // jiti/lib/jiti.mjs is the ESM entry used by cosmiconfig-typescript-loader
+      // (imported as `import { createJiti } from "jiti"`). Two patches are needed:
+      // 1. `import { createRequire } from "node:module"` — webpack drops this
+      //    harmony import when bundling to CJS, leaving createRequire undefined.
+      //    Replace with a CJS-style __non_webpack_require__ call.
+      // 2. `const nativeImport = (id) => import(id)` — webpack cannot statically
+      //    resolve the dynamic import argument; redirect to __non_webpack_require__.
       {
         enforce: 'pre',
         test: /jiti[\/\\]lib[\/\\]jiti\.mjs/,
         loader: 'string-replace-loader',
         options: {
-          search: 'const nativeImport = (id) => import(id);',
-          replace: 'const nativeImport = (id) => __non_webpack_require__(id);',
-          strict: true,
+          multiple: [
+            {
+              search: 'import { createRequire } from "node:module";',
+              replace:
+                'const { createRequire } = __non_webpack_require__("node:module");',
+              strict: true,
+            },
+            {
+              search: 'const nativeImport = (id) => import(id);',
+              replace:
+                'const nativeImport = (id) => __non_webpack_require__(id);',
+              strict: true,
+            },
+          ],
         },
       },
       // jiti/lib/jiti.cjs is the CJS entry reached via


### PR DESCRIPTION
## Summary

- Fixes `TypeError: i.createRequire is not a function` thrown when a workspace contains a TypeScript commitlint config (`.commitlintrc.ts`, `commitlint.config.ts`, etc.)
- `cosmiconfig-typescript-loader` imports `jiti` via the ESM entry (`jiti/lib/jiti.mjs`), whose `import { createRequire } from "node:module"` was being dropped by webpack when bundling to CJS, leaving `createRequire: undefined` passed to `_createJiti`
- Also ports the #391 fix (stop redirecting `parse-json`/`js-yaml` to `__non_webpack_require__`) onto this branch so the bundle is self-consistent

## Root Cause

Two `string-replace-loader` patches in `webpack.config.js` were needed:

1. **`jiti/lib/jiti.mjs`** — its ESM `import { createRequire } from "node:module"` is silently dropped when webpack converts ESM→CJS output, leaving `createRequire: undefined` at the `_createJiti(id, opts, { …, createRequire })` call site. Replaced with `const { createRequire } = __non_webpack_require__("node:module")`.
2. **`jiti/lib/jiti.cjs`** — the CJS entry (reached when something `require("jiti")`) also calls `require("node:module")` for `createRequire`. webpack was bundling `node:module` as an empty stub. Replaced with `__non_webpack_require__("node:module")` so Node resolves the real built-in.

## Test plan

- [x] `yarn test` — 24 unit tests pass (includes new regression test loading `.commitlintrc.ts` via jiti)
- [x] `yarn webpack` — bundle compiles without error; `strict: true` guards confirm all patched lines still match
- [x] `yarn test:e2e` — 7 tests pass, including:
  - `loads type-enum from a TypeScript commitlintrc (issue #395 regression)` — writes `.commitlintrc.ts` to mock repo and asserts `ts-fix` type is picked up end-to-end
  - `dist/extension.js externalises node:module and passes createRequire to createJiti (issue #395 regression)` — bundle-level assertion
  - All pre-existing #383 and #391 regression tests continue to pass