### PR TITLE
fix: avoid duplicate repository selection during auto-commit

### DIFF
--- a/e2e-test/suite/conventional-commits.test.ts
+++ b/e2e-test/suite/conventional-commits.test.ts
@@ -212,6 +212,21 @@ suite('extension.conventionalCommits e2e', () => {
       `command ${COMMAND_ID} should be registered`,
     );
 
+    let gitCommitArgument: unknown;
+    const commandApi = vscode.commands as unknown as {
+      executeCommand: (
+        command: string,
+        ...rest: unknown[]
+      ) => Thenable<unknown>;
+    };
+    const originalExecuteCommand = commandApi.executeCommand;
+    commandApi.executeCommand = (command, ...rest) => {
+      if (command === 'git.commit') {
+        gitCommitArgument = rest[0];
+      }
+      return originalExecuteCommand.call(vscode.commands, command, ...rest);
+    };
+
     // ----------------------------------------------------------------------
     // Set up the inputBox.value capture before kicking off the command. The
     // production code sets `repository.inputBox.value = serialized` and then
@@ -347,6 +362,8 @@ suite('extension.conventionalCommits e2e', () => {
       // the multi-repo quick-pick branch in `getRepository`.
       await vscode.commands.executeCommand(COMMAND_ID, repository.rootUri);
     } finally {
+      commandApi.executeCommand = originalExecuteCommand;
+
       // Restore the original `inputBox` accessor on the prototype if we
       // installed our own.
       if (originalDescriptor) {
@@ -400,6 +417,15 @@ suite('extension.conventionalCommits e2e', () => {
       `HEAD commit message should contain the test subject — got ${JSON.stringify(
         headMessage,
       )}`,
+    );
+    assert.ok(
+      gitCommitArgument instanceof vscode.Uri,
+      'git.commit should receive a repository URI instead of prompting for the repository again',
+    );
+    assert.strictEqual(
+      (gitCommitArgument as vscode.Uri).fsPath,
+      repository.rootUri.fsPath,
+      'git.commit should reuse the repository selected by the extension',
     );
 
     // Bonus: confirm the prompt machine consumed every scripted answer in

--- a/src/lib/conventional-commits.ts
+++ b/src/lib/conventional-commits.ts
@@ -181,7 +181,7 @@ export default function createConventionalCommits() {
       // 7. auto commit
       const autoCommit = configuration.get<boolean>('autoCommit');
       if (autoCommit && !showEditor) {
-        await vscode.commands.executeCommand('git.commit', repository);
+        await vscode.commands.executeCommand('git.commit', repository.rootUri);
         output.info('Auto commit finished successfully.');
       }
 


### PR DESCRIPTION
## Problem

The extension already resolves the user's repository before collecting the commit message. Passing the Git API repository wrapper to VS Code's built-in `git.commit` command is version-sensitive; if VS Code cannot resolve that wrapper, it opens another repository picker and asks the user to select the same repository again.

## Solution

- Pass the selected repository's root URI to `git.commit`.
- Add an extension-host assertion that verifies auto-commit reuses that exact repository.

The root URI is part of the stable command-routing surface and identifies the selected repository directly.

## Verification

- `yarn test` passed — 27 tests
- `yarn compile` passed
- `tsc -p e2e-test` passed
- Prettier passed for the changed files
- Extension-host bundle checks passed — 5 tests

### Environment note

The full extension-host flow did not reach the command assertion locally because VS Code 1.131's Git extension did not discover the temporary test repository within the harness's 30-second setup timeout. Bundling and the independent bundle sanity suite completed successfully.

Fixes #349