### PR TITLE
fix(commitlint): give an actionable error for ERR_PACKAGE_PATH_NOT_EX…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 !src/lib/__tests__/fixtures/should-report-single-error-for-broken-parser-preset/node_modules/
 !src/lib/__tests__/fixtures/should-report-single-error-for-broken-parser-preset/node_modules/**
+!src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/node_modules/
+!src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/node_modules/**
 out/
 e2e-test/out/
 .vscode-test/

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ You can access VSCode Conventional Commits in two ways:
 |     `conventionalCommits.promptScopes`     |                                                                                                                                        Control whether the extension should prompt for the `scope` section.                                                                                                                                         |  true   |
 |        `conventionalCommits.scopes`        |                                                                                                                                                Specify available selections in the `scope` section.                                                                                                                                                 |   []    |
 |      `conventionalCommits.promptTag`       |                                                                                                                                         Control whether the extension should prompt for the `tag` section.                                                                                                                                          |  false  |
-|        `conventionalCommits.tags`          |                                                                                                                                                 Specify available selections in the `tag` section.                                                                                                                                                  |   []    |
+|         `conventionalCommits.tags`         |                                                                                                                                                 Specify available selections in the `tag` section.                                                                                                                                                  |   []    |
 |      `conventionalCommits.showEditor`      |                                                                                                                         Control whether the extension should show the commit message as a text document in a separate tab.                                                                                                                          |  false  |
 | `conventionalCommits.showNewVersionNotes`  |                                                                                                                                          Control whether the extension should show the new version notes.                                                                                                                                           |  true   |
 |   `conventionalCommits.silentAutoCommit`   |                                                                                                                                  Control that auto commit should be silent, without focusing source control panel.                                                                                                                                  |  false  |
 | `conventionalCommits.editor.keepAfterSave` |                                                                                                                           Control whether the extension should keep the editor tab open after saving the commit message.                                                                                                                            |  false  |
-|     `conventionalCommits.storeScopesGlobally`  |                                                                                                          Control whether the extension should store the defined scopes within your user settings. Uncheck to store in workspace settings.                                                                                                           |  false  |
-|      `conventionalCommits.storeTagsGlobally`   |                                                                                                           Control whether the extension should store the defined tags within your user settings. Uncheck to store in workspace settings.                                                                                                           |  false  |
+| `conventionalCommits.storeScopesGlobally`  |                                                                                                          Control whether the extension should store the defined scopes within your user settings. Uncheck to store in workspace settings.                                                                                                           |  false  |
+|  `conventionalCommits.storeTagsGlobally`   |                                                                                                           Control whether the extension should store the defined tags within your user settings. Uncheck to store in workspace settings.                                                                                                            |  false  |
 
 ## Commit Workflow
 
@@ -142,6 +142,37 @@ Or `\\n` in JSON format.
 **A:** The extension - [vscode-commitlint] will helpful!
 
 [vscode-commitlint]: https://github.com/joshbolduc/vscode-commitlint
+
+**Q:** Why do I see an error like
+`No "exports" main defined in .../node_modules/conventional-changelog-conventionalcommits/package.json`
+(or `ERR_PACKAGE_PATH_NOT_EXPORTED`), and type/scope suggestions are empty?
+
+**A:** This is a known, currently-open upstream bug in `commitlint`
+([commitlint#4864](https://github.com/conventional-changelog/commitlint/issues/4864)):
+`@commitlint/config-conventional` sets its `parserPreset` to
+`conventional-changelog-conventionalcommits`, but that package's v10.x releases
+ship an ESM-only `exports` field with no `require`/`default` condition, which
+Node cannot resolve. Pin `conventional-changelog-conventionalcommits` to `9.3.1`
+in your project to work around it, e.g. via `"resolutions"` in `package.json`
+for Yarn:
+
+```json
+{
+  "resolutions": {
+    "conventional-changelog-conventionalcommits": "9.3.1"
+  }
+}
+```
+
+or `"overrides"` for npm:
+
+```json
+{
+  "overrides": {
+    "conventional-changelog-conventionalcommits": "9.3.1"
+  }
+}
+```
 
 ## Troubleshooting
 

--- a/src/lib/__tests__/commitlint.test.ts
+++ b/src/lib/__tests__/commitlint.test.ts
@@ -81,8 +81,9 @@ test('should load TypeScript config (regression for issue #395 / jiti.cjs create
 // resolves to a package with an ESM-only `exports` map (no `require`/
 // `default` condition) makes @commitlint/resolve-extends throw
 // ERR_PACKAGE_PATH_NOT_EXPORTED. loadRuleConfigs must still report the
-// failure through a single toast, not two.
-test('should report a single error when a parser preset is unresolvable (issue #417)', async function () {
+// failure through a single toast, not two, and the toast must explain the
+// ESM-only-exports cause rather than surface the raw Node error text.
+test('should report a single, explanatory error when a parser preset is unresolvable (issue #417)', async function () {
   vi.mocked(output.error).mockClear();
   const rules = await commitlint.loadRuleConfigs(
     path.join(
@@ -93,4 +94,32 @@ test('should report a single error when a parser preset is unresolvable (issue #
   expect(rules).toStrictEqual({});
   expect(commitlint.getTypeEnum()).toStrictEqual([]);
   expect(output.error).toHaveBeenCalledTimes(1);
+  const [, message] = vi.mocked(output.error).mock.calls[0];
+  expect(message).toContain('pkg-esm-only');
+  expect(message).toContain('ESM-only "exports" field');
+});
+
+// Regression test for issue #417: when the unresolvable parserPreset is
+// specifically `conventional-changelog-conventionalcommits` (the package
+// @commitlint/config-conventional sets as its parserPreset, and whose v10.x
+// releases ship an ESM-only `exports` map), the toast must name the known
+// upstream commitlint bug and the documented workaround (pin to 9.3.1)
+// instead of a generic message.
+test('should report an actionable error naming the pin-to-9.3.1 workaround for conventional-changelog-conventionalcommits (issue #417)', async function () {
+  vi.mocked(output.error).mockClear();
+  const rules = await commitlint.loadRuleConfigs(
+    path.join(
+      fixtureRootPath,
+      'should-report-actionable-error-for-conventionalcommits-preset',
+    ),
+  );
+  expect(rules).toStrictEqual({});
+  expect(commitlint.getTypeEnum()).toStrictEqual([]);
+  expect(output.error).toHaveBeenCalledTimes(1);
+  const [, message] = vi.mocked(output.error).mock.calls[0];
+  expect(message).toContain('conventional-changelog-conventionalcommits');
+  expect(message).toContain('9.3.1');
+  expect(message).toContain(
+    'https://github.com/conventional-changelog/commitlint/issues/4864',
+  );
 });

--- a/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/commitlint.config.js
+++ b/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/commitlint.config.js
@@ -1,0 +1,3 @@
+export default {
+  extends: ['./local-config.js'],
+};

--- a/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/local-config.js
+++ b/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/local-config.js
@@ -1,0 +1,3 @@
+export default {
+  parserPreset: 'conventional-changelog-conventionalcommits',
+};

--- a/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/node_modules/conventional-changelog-conventionalcommits/package.json
+++ b/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/node_modules/conventional-changelog-conventionalcommits/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "conventional-changelog-conventionalcommits",
+  "version": "10.2.1",
+  "type": "module",
+  "exports": {
+    "types": "./src/index.d.ts",
+    "import": "./src/index.js"
+  }
+}

--- a/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/node_modules/conventional-changelog-conventionalcommits/src/index.js
+++ b/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/node_modules/conventional-changelog-conventionalcommits/src/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/package.json
+++ b/src/lib/__tests__/fixtures/should-report-actionable-error-for-conventionalcommits-preset/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "should-report-actionable-error-for-conventionalcommits-preset",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/src/lib/commitlint.ts
+++ b/src/lib/commitlint.ts
@@ -20,6 +20,33 @@ type Commit = {
 };
 import * as output from './output';
 
+// `ERR_PACKAGE_PATH_NOT_EXPORTED` is Node's stable error code (not just a
+// message string) for a `require()` resolution hitting a package.json
+// `exports` map that has no `require`/`default` condition — e.g. a pure-ESM
+// package. commitlint hits this via `@commitlint/resolve-extends`'s
+// `parserPreset` resolution (see issue #417): `@commitlint/config-conventional`
+// sets `parserPreset: 'conventional-changelog-conventionalcommits'`, and if a
+// project's installed copy of that package is v10.x, its `exports` field is
+// `{"import": "./src/index.js"}` with no CJS fallback.
+function formatUnexportedPackageError(e: NodeJS.ErrnoException): string {
+  const match = e.message.match(/[\\/]([^\\/]+)[\\/]package\.json$/);
+  const packageName = match ? match[1] : undefined;
+  if (packageName === 'conventional-changelog-conventionalcommits') {
+    return (
+      `commitlint: "conventional-changelog-conventionalcommits" ships an ESM-only "exports" field ` +
+      `(no "require"/"default" condition), so Node cannot load it here. This is a known upstream ` +
+      `commitlint issue (https://github.com/conventional-changelog/commitlint/issues/4864) with no fix yet. ` +
+      `Workaround: pin "conventional-changelog-conventionalcommits" to "9.3.1" in your project, e.g. via ` +
+      `"resolutions" in package.json (Yarn) or "overrides" (npm).`
+    );
+  }
+  return (
+    `commitlint: ${packageName ?? 'a commitlint config dependency'} ships an ESM-only "exports" field ` +
+    `(no "require"/"default" condition), so Node cannot load it here. Pinning that package to a version ` +
+    `with a CommonJS-compatible "exports" field should resolve this.`
+  );
+}
+
 class Commitlint {
   private ruleConfigs: Partial<RulesConfig> = {};
   private promptConfig?: UserPromptConfig;
@@ -36,6 +63,17 @@ class Commitlint {
           if (e.message.startsWith('Cannot find module')) {
             output.warning(`commitlint: The cwd is ${cwd}`);
             output.warning(`commitlint: ${e.message}`);
+          } else if (
+            (e as NodeJS.ErrnoException).code ===
+            'ERR_PACKAGE_PATH_NOT_EXPORTED'
+          ) {
+            output.appendLine(`[error] commitlint: The cwd is ${cwd}`);
+            output.appendLine(`[error] commitlint: ${e.stack}`);
+            // Not break even if it gets configuration failure.
+            output.error(
+              'commitlint',
+              formatUnexportedPackageError(e as NodeJS.ErrnoException),
+            );
           } else {
             output.appendLine(`[error] commitlint: The cwd is ${cwd}`);
             // Not break even if it gets configuration failure.


### PR DESCRIPTION
…PORTED

@commitlint/resolve-extends@21 eagerly resolves parserPreset strings from extended configs. When a project's conventional-changelog-conventionalcommits copy is v10.x, its ESM-only exports map (no require/default condition) makes that resolution throw ERR_PACKAGE_PATH_NOT_EXPORTED, wiping out all rules. This is a known, currently-open upstream bug (commitlint#4864) with no fix available, so name the offending package in the toast and point at the documented pin-to-9.3.1 workaround instead of surfacing the raw Node error. Also document it in the README FAQ.

resolve #417